### PR TITLE
Use Alpine, add parallel env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM ubuntu:20.04
+FROM ghcr.io/linuxserver/baseimage-alpine:3.20-version-6315bc7d
 
-RUN apt update && apt install -y \
+RUN apk add -U --upgrade --no-cache \
     lftp \
-    cron \
-    vim \
-    curl \
- && apt upgrade -y && rm -rf /var/lib/apt/lists/*
+    apk-cron
 
 ADD crontab /etc/cron.d/hello-cron
 ADD scripts /var/scripts
@@ -14,9 +11,6 @@ RUN chmod 0644 /etc/cron.d/hello-cron
 
 RUN touch /var/log/cron.log
 RUN touch /var/log/lftp.log
-
-RUN mkdir /root/.ssh && echo 'ariel.whatbox.ca,72.21.17.8 ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBABCJTdYFtRKJCLkydzAFZDfQroHWlWTES21HEY1jBBlQrKWcxZgPE+7eW4d550QuLVaBhQnj/wCjaUDcyaptPoHqgDdzZGa85crQCU+SJNbKAxdpzFNhFXKdGSDPPokQ8slXFyGzvK+ztToctc6CDVSYV95uRk/lPRn0BU81Lr85oyxWw==' > /root/.ssh/known_hosts
-
 RUN mkdir -p /media
 
 CMD printenv | sed 's/^\(.*\)$/export \1/g' | sed 's/=\(.*\)/="\1"/' > /env.sh && cron && tail -f /var/log/cron.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN chmod 0644 /etc/cron.d/hello-cron
 
 RUN touch /var/log/cron.log
 RUN touch /var/log/lftp.log
+
+RUN mkdir /root/.ssh && echo 'ariel.whatbox.ca,72.21.17.8 ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBABCJTdYFtRKJCLkydzAFZDfQroHWlWTES21HEY1jBBlQrKWcxZgPE+7eW4d550QuLVaBhQnj/wCjaUDcyaptPoHqgDdzZGa85crQCU+SJNbKAxdpzFNhFXKdGSDPPokQ8slXFyGzvK+ztToctc6CDVSYV95uRk/lPRn0BU81Lr85oyxWw==' > /root/.ssh/known_hosts
+
 RUN mkdir -p /media
 
 CMD printenv | sed 's/^\(.*\)$/export \1/g' | sed 's/=\(.*\)/="\1"/' > /env.sh && cron && tail -f /var/log/cron.log

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -36,7 +36,7 @@ then
     lftp -u $login,$pass $host
     mirror -c -P4 --no-perms --dereference --Remove-source-files --log=/var/log/lftp.log -x ^[^\\/]*$ -vvv $remote_dir $local_dir
     quit
-    EOF
+EOF
   else
     echo "Skipping $remote_dir .. $local_dir is empty"
   fi

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -6,6 +6,7 @@ pass=$LFTP_PASSWORD
 host=sftp://$LFTP_HOST
 base_remote_dir=$LFTP_REMOTE_DIR
 base_local_dir=/media
+parallel=${LFTP_PARALLEL:-4}
 
 set -e
 
@@ -34,7 +35,7 @@ then
     set sftp:auto-confirm yes
     set mirror:use-pget-n 4
     lftp -u $login,$pass $host
-    mirror -c -P4 --no-perms --dereference --Remove-source-files --log=/var/log/lftp.log -x ^[^\\/]*$ -vvv $remote_dir $local_dir
+    mirror -c -P=$parallel --no-perms --dereference --Remove-source-files --log=/var/log/lftp.log -x ^[^\\/]*$ -vvv $remote_dir $local_dir
     quit
 EOF
   else

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -9,14 +9,14 @@ base_local_dir=/media
 
 set -e
 
-if [ -e /config/synctorrent.lock ]
+if [ -e /config/lftp-sync.lock ]
 then
   echo "Sync is running already."
   exit 1
 else
-  touch /config/synctorrent.lock
+  touch /config/lftp-sync.lock
 
-trap "rm -f /config/synctorrent.lock" EXIT
+trap "rm -f /config/lftp-sync.lock" EXIT
 
 sync_dir() {
 
@@ -59,6 +59,6 @@ echo "sync_dir() done"
 
   echo "Sync Done: $(date)"
 
-  rm -f /config/synctorrent.lock
+  rm -f /config/lftp-sync.lock
   exit 0
 fi


### PR DESCRIPTION
Switches to using an Alpine base image - specifically the one used by many linuxserver things, popular un UnRAID deployments. This enables the use of [`PUID` and `PGID`](https://docs.linuxserver.io/general/understanding-puid-and-pgid/), which I also need.

Some other small changes because multiple PRs is no fun:

* Adds an environment variable handling for `$LFTP_PARALLEL` - if set (defaults to 4), it's used in the call to `lftp mirror -P=$parallel`.
* Renames the lock file to `lftp-sync.lock`. That's just more consistent with other naming.